### PR TITLE
Hash lookup optimizations

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -8,6 +8,6 @@ description: |
 authors:
   - Joel <da1nerd@pm.me>
 
-crystal: 0.35.1
+crystal: 1.0.0
 
 license: MIT

--- a/src/dsl/variable.cr
+++ b/src/dsl/variable.cr
@@ -2,7 +2,7 @@ require "../variable_state.cr"
 
 module Kiwi
   # This is a light wrapper around the actual `VariableState` that provides some helpful operators.
-  class Variable
+  struct Variable
     @state : VariableState
 
     # :nodoc:


### PR DESCRIPTION
I sent the benchmark spec through Callgrind a few times and found several redundant hash table lookups, so I took a few minutes to replace them with some straightforward optimizations---`has_key?/[key]` to a local variable alternative, for instance, or `transform_values!` for `each_key/[key]=`. Crystal's standard hash table doesn't cache lookups as far as I can tell, so multiple lookups of the same key mean a lot of unnecessary cycles.

After a performance check again, it looks like the optimizations, minor as they are, result in a decent processing time speedup (~40-50s instead of ~50-70s for the 3000-constraint stress test on my machine) which is great for now until a potential full structural refactor.